### PR TITLE
Fix for the composer require package version syntax in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ __TIP__ *It's advised you either have __[Elasticsuite](https://github.com/Smile-
 __elasticsearch__ up and running on `localhost:9200` prior to executing the `setup:upgrade` or it will fail.*
 
 * (optional) [Install Magento](https://devdocs.magento.com/guides/v2.2/install-gde/prereq/integrator_install.html) if you don't have it yet 
-* Execute `composer require creativestyle/magesuite ^2.0.0`
+* Execute `composer require "creativestyle/magesuite:^2.0.0"`
 * Execute `bin/magento setup:upgrade`
 * Build the theme (next chapter)
 * Flush Magento cache


### PR DESCRIPTION
The second option is to omit the version range and just go with
```
composer require creativestyle/magesuite
```
which will get just the latest stable.